### PR TITLE
Hotfix/partner id transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - updated release pipeline to use travis [#73](https://github.com/xmidt-org/scytale/pull/73)
 - bumped bascule, webpa-common, and wrp-go for updated capability configuration [#75](https://github.com/xmidt-org/scytale/pull/75)
+- fix feature for passing partnerIDs from JWT to fanout WRP messages [#79](https://github.com/xmidt-org/scytale/pull/79)
 
 ## [v0.1.5]
 - converting glide to go mod

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/influxdata/influxdb v1.7.7 // indirect
 	github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/prometheus/client_golang v1.0.0 // indirect
 	github.com/samuel/go-zookeeper v0.0.0-20190810000440-0ceca61e4d75 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.4.0
+	github.com/stretchr/testify v1.3.0
 	github.com/xmidt-org/bascule v0.7.0
 	github.com/xmidt-org/webpa-common v1.5.1
 	github.com/xmidt-org/wrp-go v1.3.3

--- a/primaryHandler.go
+++ b/primaryHandler.go
@@ -52,12 +52,12 @@ const (
 	version = "v2"
 )
 
-type AllowedResources struct {
+type allowedResources struct {
 	AllowedPartners []string
 }
 
-type Claims struct {
-	AllowedResources AllowedResources
+type claims struct {
+	AllowedResources allowedResources
 	Sub              string
 }
 
@@ -80,7 +80,7 @@ func GetLogger(ctx context.Context) bascule.Logger {
 func populateMessage(ctx context.Context, message *wrp.Message, logger log.Logger) {
 	if auth, ok := bascule.FromContext(ctx); ok {
 		if token := auth.Token; token != nil {
-			var claims Claims
+			var claims claims
 
 			err := mapstructure.Decode(auth.Token.Attributes(), &claims)
 			if err != nil {
@@ -93,7 +93,6 @@ func populateMessage(ctx context.Context, message *wrp.Message, logger log.Logge
 			}
 
 			message.PartnerIDs = claims.AllowedResources.AllowedPartners
-
 		}
 	}
 }

--- a/primaryHandler.go
+++ b/primaryHandler.go
@@ -58,7 +58,6 @@ type allowedResources struct {
 
 type claims struct {
 	AllowedResources allowedResources
-	Sub              string
 }
 
 func SetLogger(logger log.Logger) func(delegate http.Handler) http.Handler {
@@ -84,12 +83,12 @@ func populateMessage(ctx context.Context, message *wrp.Message, logger log.Logge
 
 			err := mapstructure.Decode(auth.Token.Attributes(), &claims)
 			if err != nil {
-				logging.Warn(logger, logging.MessageKey(), "error decoding JWT claims for fanout WRP message", logging.ErrorKey(), err)
+				logging.Warn(logger, logging.MessageKey(), "error decoding JWT claims for fanout WRP message", logging.ErrorKey(), err, "clientID", token.Principal())
 				return
 			}
 
 			if len(claims.AllowedResources.AllowedPartners) < 1 {
-				logging.Warn(logger, logging.MessageKey(), "empty JWT partnerID claims for fanout WRP message", "sub", claims.Sub)
+				logging.Warn(logger, logging.MessageKey(), "empty JWT partnerID claims for fanout WRP message", "clientID", token.Principal())
 			}
 
 			message.PartnerIDs = claims.AllowedResources.AllowedPartners

--- a/primaryHandler.go
+++ b/primaryHandler.go
@@ -81,7 +81,7 @@ func populateMessage(ctx context.Context, message *wrp.Message, logger log.Logge
 		if token := auth.Token; token != nil {
 			var claims claims
 
-			err := mapstructure.Decode(auth.Token.Attributes(), &claims)
+			err := mapstructure.Decode(token.Attributes(), &claims)
 			warnLogger := logging.Warn(logger)
 			if err != nil {
 				warnLogger.Log(logging.MessageKey(), "error decoding JWT claims for fanout WRP message", logging.ErrorKey(), err, "clientID", token.Principal())

--- a/primaryHandler.go
+++ b/primaryHandler.go
@@ -82,13 +82,14 @@ func populateMessage(ctx context.Context, message *wrp.Message, logger log.Logge
 			var claims claims
 
 			err := mapstructure.Decode(auth.Token.Attributes(), &claims)
+			warnLogger := logging.Warn(logger)
 			if err != nil {
-				logging.Warn(logger, logging.MessageKey(), "error decoding JWT claims for fanout WRP message", logging.ErrorKey(), err, "clientID", token.Principal())
+				warnLogger.Log(logging.MessageKey(), "error decoding JWT claims for fanout WRP message", logging.ErrorKey(), err, "clientID", token.Principal())
 				return
 			}
 
 			if len(claims.AllowedResources.AllowedPartners) < 1 {
-				logging.Warn(logger, logging.MessageKey(), "empty JWT partnerID claims for fanout WRP message", "clientID", token.Principal())
+				warnLogger.Log(logging.MessageKey(), "empty JWT partnerID claims for fanout WRP message", "clientID", token.Principal())
 			}
 
 			message.PartnerIDs = claims.AllowedResources.AllowedPartners

--- a/primaryHandler_test.go
+++ b/primaryHandler_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/xmidt-org/bascule"
+	"github.com/xmidt-org/webpa-common/logging"
+	"github.com/xmidt-org/wrp-go/wrp"
+	"testing"
+)
+
+func TestPopulateMessagePartners(t *testing.T) {
+	var tests = []struct {
+		name               string
+		attributes         bascule.Attributes
+		expectedPartnerIDs []string
+	}{
+		{
+			name: "partnerIDs",
+			attributes: map[string]interface{}{
+				"allowedResources": map[string]interface{}{
+					"allowedPartners": []string{"partner0", "partner1"},
+				}},
+			expectedPartnerIDs: []string{"partner0", "partner1"},
+		},
+
+		{
+			name:               "no partnerIDs",
+			attributes:         nil,
+			expectedPartnerIDs: nil,
+		},
+		{
+			name: "malformed partnerIDs field",
+			attributes: map[string]interface{}{
+				"allowedResources": map[string]interface{}{
+					"allowedPartners": "partner0",
+				}},
+			expectedPartnerIDs: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			auth := bascule.Authentication{
+				Token: bascule.NewToken("bearer", "client0", test.attributes),
+			}
+
+			ctx := bascule.WithAuthentication(context.Background(), auth)
+
+			wrpMsg := new(wrp.Message)
+			populateMessage(ctx, wrpMsg, logging.DefaultLogger())
+			assert.Equal(test.expectedPartnerIDs, wrpMsg.PartnerIDs)
+		})
+	}
+}


### PR DESCRIPTION
This PR fix the issue in which scytale was not transferring the partnerIDs field from the JWT token into the fanout WRP message