### PR TITLE
Fix override of logger in request context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Updated spec file and rpkg version macro to be able to choose when the 'v' is included in the version. [#163](https://github.com/xmidt-org/scytale/pull/163)
+- Reconfigured the Bascule Logger settings so that the logger isn't overwritten [#166](https://github.com/xmidt-org/scytale/pull/166)
 
 ## [v0.6.1]
 - Fixed url parsing bug where we were leaving a '/'. [#161](https://github.com/xmidt-org/scytale/pull/161)

--- a/basculeLogging.go
+++ b/basculeLogging.go
@@ -10,6 +10,11 @@ import (
 	"github.com/xmidt-org/webpa-common/v2/logging"
 )
 
+// LoggerFunc is a strategy for adding key/value pairs (possibly) based on an HTTP request.
+// Functions of this type must append key/value pairs to the supplied slice and then return
+// the new slice.
+type LoggerFunc func([]interface{}, *http.Request) []interface{}
+
 func sanitizeHeaders(headers http.Header) (filtered http.Header) {
 	filtered = headers.Clone()
 	if authHeader := filtered.Get("Authorization"); authHeader != "" {
@@ -22,11 +27,33 @@ func sanitizeHeaders(headers http.Header) (filtered http.Header) {
 	return
 }
 
-func setLogger(logger log.Logger) func(delegate http.Handler) http.Handler {
+// func setLogger(logger log.Logger) func(delegate http.Handler) http.Handler {
+// 	return func(delegate http.Handler) http.Handler {
+// 		return http.HandlerFunc(
+// 			func(w http.ResponseWriter, r *http.Request) {
+// 				kvs := []interface{}{"requestHeaders", sanitizeHeaders(r.Header), "requestURL", r.URL.EscapedPath(), "method", r.Method}
+// 				kvs, _ = candlelight.AppendTraceInfo(r.Context(), kvs)
+// 				ctx := r.WithContext(logging.WithLogger(r.Context(), log.With(logger, kvs...)))
+// 				delegate.ServeHTTP(w, ctx)
+// 			})
+// 	}
+// }
+
+func setLogger(logger log.Logger, lf ...LoggerFunc) func(delegate http.Handler) http.Handler {
+
+	if logger == nil {
+		panic("The base Logger cannot be nil")
+	}
+
 	return func(delegate http.Handler) http.Handler {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				kvs := []interface{}{"requestHeaders", sanitizeHeaders(r.Header), "requestURL", r.URL.EscapedPath(), "method", r.Method}
+				if len(lf) > 0 {
+					for _, f := range lf {
+						kvs = f(kvs, r)
+					}
+				}
 				kvs, _ = candlelight.AppendTraceInfo(r.Context(), kvs)
 				ctx := r.WithContext(logging.WithLogger(r.Context(), log.With(logger, kvs...)))
 				delegate.ServeHTTP(w, ctx)

--- a/basculeLogging.go
+++ b/basculeLogging.go
@@ -27,18 +27,6 @@ func sanitizeHeaders(headers http.Header) (filtered http.Header) {
 	return
 }
 
-// func setLogger(logger log.Logger) func(delegate http.Handler) http.Handler {
-// 	return func(delegate http.Handler) http.Handler {
-// 		return http.HandlerFunc(
-// 			func(w http.ResponseWriter, r *http.Request) {
-// 				kvs := []interface{}{"requestHeaders", sanitizeHeaders(r.Header), "requestURL", r.URL.EscapedPath(), "method", r.Method}
-// 				kvs, _ = candlelight.AppendTraceInfo(r.Context(), kvs)
-// 				ctx := r.WithContext(logging.WithLogger(r.Context(), log.With(logger, kvs...)))
-// 				delegate.ServeHTTP(w, ctx)
-// 			})
-// 	}
-// }
-
 func setLogger(logger log.Logger, lf ...LoggerFunc) func(delegate http.Handler) http.Handler {
 
 	if logger == nil {

--- a/basculeLogging.go
+++ b/basculeLogging.go
@@ -37,8 +37,8 @@ func setLogger(logger log.Logger, lf ...LoggerFunc) func(delegate http.Handler) 
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				kvs := []interface{}{"requestHeaders", sanitizeHeaders(r.Header), "requestURL", r.URL.EscapedPath(), "method", r.Method}
-				if len(lf) > 0 {
-					for _, f := range lf {
+				for _, f := range lf {
+					if f != nil {
 						kvs = f(kvs, r)
 					}
 				}


### PR DESCRIPTION
- Updated so the logger is only set once. 
- The additional key-value pairs provided in the logginghttp call are added in the earlier logger setting
- the later logger setting is removed

closes #130 