### PR TITLE
JWK Migration Release v0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [v0.6.7]
+## [v0.6.8]
 - JWT Migration [183](https://github.com/xmidt-org/scytale/issues/183)
   - updated to use clortho `Resolver` & `Refresher`
   - updated to use clortho `metrics` & `logging`
@@ -125,8 +125,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Initial creation.
 
 
-[Unreleased]: https://github.com/xmidt-org/scytale/compare/v0.6.7...HEAD
-[v0.6.5]: https://github.com/xmidt-org/scytale/compare/v0.6.5...v0.6.7
+[Unreleased]: https://github.com/xmidt-org/scytale/compare/v0.6.8...HEAD
+[v0.6.8]: https://github.com/xmidt-org/scytale/compare/v0.6.5...v0.6.8
 [v0.6.5]: https://github.com/xmidt-org/scytale/compare/v0.6.4...v0.6.5
 [v0.6.4]: https://github.com/xmidt-org/scytale/compare/v0.6.3...v0.6.4
 [v0.6.3]: https://github.com/xmidt-org/scytale/compare/v0.6.2...v0.6.3


### PR DESCRIPTION
What's included:

- JWT Migration [183](https://github.com/xmidt-org/scytale/issues/183)
  - updated to use clortho `Resolver` & `Refresher`
  - updated to use clortho `metrics` & `logging`
- Update Config
  - Use [uber/zap](https://github.com/uber-go/zap) for clortho logging
  - Use [xmidt-org/sallust](https://github.com/xmidt-org/sallust) for the zap config unmarshalling 
  - Update auth config for clortho
- Dependency update
  - Introduces new vuln https://www.mend.io/vulnerability-database/CVE-2022-29526
  - [github.com/hashicorp/consul/api v1.13.1 CVE-2022-29153 patched versions 1.9.17 1.10.10 1.11.5](https://github.com/advisories/GHSA-q6h7-4qgw-2j9p)
  - guardrails says github.com/gorilla/websocket v1.5.0 has a high vulnerability but no vulnerabilities have been filed
  