### PR TITLE
Update scytale.yaml to reflect tracing status

### DIFF
--- a/scytale.yaml
+++ b/scytale.yaml
@@ -507,6 +507,7 @@ service:
 
 # tracing provides configuration around traces using OpenTelemetry.
 # (Optional). By default, a 'noop' tracer provider is used and tracing is disabled.
+# tracing for Scytale is not yet supported.
 tracing:
   # provider is the name of the trace provider to use. Currently, otlp/grpc, otlp/http, stdout, jaeger and zipkin are supported.
   # 'noop' can also be used as provider to explicitly disable tracing.


### PR DESCRIPTION
- Dependabot updated to the newest Candlelight version (which enables tracing) before all testing was complete for Scytale. 
- Added a comment to the Scytale yaml that clarifies that tracing is not ready yet.