### PR TITLE
Bug Fix: basculeHelper package Metrics function 

### DIFF
--- a/basculehelper/basculeHelper.go
+++ b/basculehelper/basculeHelper.go
@@ -60,12 +60,12 @@ const (
 	PartnerIDLabel = "partnerid"
 	ServerLabel    = "server"
 
-	//Names for Auth Validation metrics
+	// Names for Auth Validation metrics
 	AuthValidationOutcome = "auth_validation"
 	NBFHistogram          = "auth_from_nbf_seconds"
 	EXPHistogram          = "auth_from_exp_seconds"
 
-	// help messages for Auth Validation metrics
+	// Help messages for Auth Validation metrics
 	authValidationOutcomeHelpMsg = "Counter for success and failure reason results through bascule"
 	nbfHelpMsg                   = "Difference (in seconds) between time of JWT validation and nbf (including leeway)"
 	expHelpMsg                   = "Difference (in seconds) between time of JWT validation and exp (including leeway)"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/xmidt-org/scytale
 go 1.19
 
 require (
+	github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2
 	github.com/go-kit/kit v0.12.0
 	github.com/go-kit/log v0.2.1
 	github.com/goph/emperror v0.17.3-0.20190703203600-60a8d9faa17b
@@ -22,13 +23,13 @@ require (
 	github.com/xmidt-org/webpa-common/v2 v2.0.7
 	github.com/xmidt-org/wrp-go/v3 v3.1.6
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.40.0
+	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
 )
 
 require (
 	emperror.dev/emperror v0.33.0 // indirect
 	emperror.dev/errors v0.8.1 // indirect
-	github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2 // indirect
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/aws/aws-sdk-go v1.44.103 // indirect
@@ -111,7 +112,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/dig v1.15.0 // indirect
 	go.uber.org/fx v1.18.2 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.2.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.7.0 // indirect

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func scytale(arguments []string) int {
 		f = pflag.NewFlagSet(applicationName, pflag.ContinueOnError)
 		v = viper.New()
 
-		logger, metricsRegistry, webPA, err = server.Initialize(applicationName, arguments, f, v, webhook.Metrics, aws.Metrics, basculehelper.Metrics, basculehelper.Metrics, consul.Metrics, Metrics, service.Metrics)
+		logger, metricsRegistry, webPA, err = server.Initialize(applicationName, arguments, f, v, webhook.Metrics, aws.Metrics, basculehelper.AuthCapabilitiesMetrics, basculehelper.AuthValidationMetrics, consul.Metrics, Metrics, service.Metrics)
 	)
 
 	if parseErr, done := printVersion(f, arguments); done {


### PR DESCRIPTION
was calling the same metrics function twice when trying to initialize viper.

added two separate metrics functions one for AuthCapability and one for AuthValidation

Related Ticket: https://github.com/xmidt-org/scytale/issues/253