### PR TITLE
Update dockerfile for processor arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN apk add --no-cache --no-progress \
 # If arch is arm64 or aarch64, use arm64 download, else, do the amd64 default
 # Download spruce here to eliminate the need for curl in the final image
 RUN mkdir -p /go/bin && \
-    uname -m && \
     if [ $(uname -m) = "aarch64" ] || [ $(uname -m) = "arm64" ]; then export PROC_ARCH="arm64"; else export PROC_ARCH="amd64"; fi && \
     curl -L -o /go/bin/spruce https://github.com/geofffranks/spruce/releases/download/v1.29.0/spruce-linux-"${PROC_ARCH}" && \
     chmod +x /go/bin/spruce

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,12 @@ RUN apk add --no-cache --no-progress \
     libc-dev \
     upx
 
+# If arch is arm64 or aarch64, use arm64 download, else, do the amd64 default
 # Download spruce here to eliminate the need for curl in the final image
 RUN mkdir -p /go/bin && \
-    curl -L -o /go/bin/spruce https://github.com/geofffranks/spruce/releases/download/v1.29.0/spruce-linux-amd64 && \
+    uname -m && \
+    if [ $(uname -m) = "aarch64" ] || [ $(uname -m) = "arm64" ]; then export PROC_ARCH="arm64"; else export PROC_ARCH="amd64"; fi && \
+    curl -L -o /go/bin/spruce https://github.com/geofffranks/spruce/releases/download/v1.29.0/spruce-linux-"${PROC_ARCH}" && \
     chmod +x /go/bin/spruce
 
 COPY . .


### PR DESCRIPTION
## What is this PR out to accomplish?

By quizzing `uname` during build time we can ascertain the processor architecture the builder image is running under/as, and download an appropriate architecture's copy of `spruce`

Addresses https://github.com/xmidt-org/scytale/issues/265